### PR TITLE
ingest the version info into the binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-inlets
-inlets-armhf
-inlets-darwin
-inlets-arm64
+bin
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,16 @@ FROM golang:1.10 as build
 
 WORKDIR /go/src/github.com/alexellis/inlets
 
+COPY .git             .git
 COPY vendor             vendor
 COPY pkg                pkg
 COPY main.go            .
 COPY parse_upstream.go  .
 
-RUN CGO_ENABLED=0 go build -a -installsuffix cgo --ldflags "-s -w" -o /usr/bin/inlets
+ARG GIT_COMMIT
+ARG VERSION
+
+RUN CGO_ENABLED=0 go build -ldflags "-X main.GitCommit=${GIT_COMMIT} -X main.Version=${VERSION}" -a -installsuffix cgo -o /usr/bin/inlets
 
 FROM alpine:3.9
 RUN apk add --force-refresh ca-certificates

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
 TAG?=latest
+Version := $(shell git describe --tags --dirty)
+GitCommit := $(shell git rev-parse HEAD)
+LDFLAGS := "-X main.Version=$(Version) -X main.GitCommit=$(GitCommit)"
+
 .PHONY: all
 all: docker
 
 .PHONY: dist
 dist:
-	CGO_ENABLED=0 GOOS=darwin go build -a -installsuffix cgo --ldflags "-s -w" -o inlets-darwin && \
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo --ldflags "-s -w" -o inlets && \
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -a -installsuffix cgo --ldflags "-s -w" -o inlets-armhf
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -installsuffix cgo --ldflags "-s -w" -o inlets-arm64
+	CGO_ENABLED=0 GOOS=linux go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inlets
+	CGO_ENABLED=0 GOOS=darwin go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inlets-darwin
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inlets-armhf
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inlets-arm64
 
 .PHONY: docker
 docker:
-	docker build -t alexellis2/inlets:$(TAG) .
+	docker build --build-arg Version=$(Version) --build-arg GIT_COMMIT=$(GitCommit) -t alexellis2/inlets:$(TAG) .

--- a/main.go
+++ b/main.go
@@ -4,10 +4,16 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"github.com/alexellis/inlets/pkg/client"
 	"github.com/alexellis/inlets/pkg/server"
+)
+
+var (
+	Version   string
+	GitCommit string
 )
 
 // Args parsed from the command-line
@@ -20,10 +26,12 @@ type Args struct {
 	GatewayTimeout    time.Duration
 	Token             string
 	PrintServerToken  bool
+	Version           bool
 }
 
 func main() {
 	args := Args{}
+	flag.BoolVar(&args.Version, "version", false, "print version information and exit")
 	flag.IntVar(&args.Port, "port", 8000, "port for server")
 	flag.BoolVar(&args.Server, "server", true, "server or client")
 	flag.StringVar(&args.Remote, "remote", "127.0.0.1:8000", " server address i.e. 127.0.0.1:8000")
@@ -34,11 +42,16 @@ func main() {
 
 	flag.Parse()
 
+	if args.Version {
+		PrintVersionInfo()
+		os.Exit(0)
+	}
+
 	argsUpstreamParser := ArgsUpstreamParser{}
 
 	upstreamMap := map[string]string{}
 
-	if args.Server == false {
+	if !args.Server {
 
 		if len(args.Upstream) == 0 {
 			log.Printf("give --upstream\n")
@@ -87,4 +100,13 @@ func main() {
 			panic(err)
 		}
 	}
+}
+
+func PrintVersionInfo() {
+	if len(Version) == 0 {
+		fmt.Println("Version: dev")
+	} else {
+		fmt.Println("Version:", Version)
+	}
+	fmt.Println("Git Commit:", GitCommit)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -66,7 +66,6 @@ func (c *Client) Connect() error {
 			case websocket.TextMessage:
 				log.Printf("TextMessage: %s\n", message)
 
-				break
 			case websocket.BinaryMessage:
 				// proxyToUpstream
 
@@ -142,7 +141,6 @@ func (c *Client) Connect() error {
 
 					ws.WriteMessage(websocket.BinaryMessage, buf2.Bytes())
 				}
-				break
 			}
 
 		}


### PR DESCRIPTION
## Description
This PR ingests the version information from the git repo to the binary. After this PR, `-version` will print the information of the binary.

## How Has This Been Tested?
Manually test

## How are existing users impacted? What migration steps/scripts do we need?
No. It won't impact anything.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`