### PR TITLE
unrelease read lock when id not in Subscriptions

### DIFF
--- a/pkg/types/bus.go
+++ b/pkg/types/bus.go
@@ -40,6 +40,8 @@ func (b *Bus) Send(id string, res *http.Response) {
 	var ok bool
 
 	b.Mutex.RLock()
+	defer b.Mutex.RUnlock()
+	
 	_, ok = b.Subscriptions[id]
 
 	if !ok {
@@ -47,7 +49,6 @@ func (b *Bus) Send(id string, res *http.Response) {
 	}
 
 	b.Subscriptions[id].Data <- res
-	b.Mutex.RUnlock()
 }
 
 func (b *Bus) Subscribe(id string) *Subscription {


### PR DESCRIPTION
## unrelease read lock when id not in Subscriptions


## How Has This Been Tested?

When I read the code, I found this bug


## How are existing users impacted? What migration steps/scripts do we need?

no user will be impacted.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [ ] signed-off my commits with `git commit -s`
- [ ] added unit tests
