### PR TITLE
bugfix: initialize http.Response.Header when create error response in…

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -115,6 +115,7 @@ func (c *Client) Connect() error {
 					errRes := http.Response{
 						StatusCode: http.StatusBadGateway,
 						Body:       ioutil.NopCloser(strings.NewReader(resErr.Error())),
+						Header:     make(http.Header, 1),
 					}
 					errRes.Header.Set(transport.InletsHeader, inletsID)
 					buf2 := new(bytes.Buffer)


### PR DESCRIPTION
 initialize http.Response.Header when create error response in client

Signed-off-by: mylxsw<mylxsw@aicode.cc>

Bugfix:

	2019/02/23 12:47:30 [b04fa13c879e40c2857b4a2b3be01f57] Upstream tunnel err: Get http://127.0.0.1:80/: dial tcp 127.0.0.1:80: connect: connection refused
	panic: assignment to entry in nil map

	goroutine 35 [running]:
	net/textproto.MIMEHeader.Set(0x0, 0x130f35c, 0xb, 0xc00012e160, 0x20)
		/usr/local/Cellar/go/1.11.4/libexec/src/net/textproto/header.go:22 +0xaf
	net/http.Header.Set(0x0, 0x130f35c, 0xb, 0xc00012e160, 0x20)
		/usr/local/Cellar/go/1.11.4/libexec/src/net/http/header.go:32 +0x53
	github.com/alexellis/inlets/pkg/client.(*Client).Connect.func2(0xc000160000, 0xc000142000, 0xc000096f30)
		/Users/mylxsw/codes/golang/pkg/mod/github.com/alexellis/inlets@v0.0.0-20190221124520-15ad2db892ab/pkg/client/client.go:119 +0x97c
	created by github.com/alexellis/inlets/pkg/client.(*Client).Connect
		/Users/mylxsw/codes/golang/pkg/mod/github.com/alexellis/inlets@v0.0.0-20190221124520-15ad2db892ab/pkg/client/client.go:56 +0x401