### PR TITLE
Add release script for different distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,46 @@
 sudo: required
 
+language: generic
+
 services:
   - docker
 
+addons:
+  apt:
+    packages:
+      - docker-ce
+
 script:
-  - make docker
+  - make build
+
+after_success:
+    - if [ ! -z "$TRAVIS_TAG" ] ; then
+        if [ -z "$DOCKER_NS" ] ; then
+          export DOCKER_NS=alexellis2;
+        fi;
+
+        docker tag $DOCKER_NS/inlets:latest $DOCKER_NS/inlets:$TRAVIS_TAG;
+        echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
+        docker push $DOCKER_NS/inlets:$TRAVIS_TAG;
+      fi;
+
+before_deploy:
+  - make build_redist
+  - ./ci/hashgen.sh
+
+deploy:
+  provider: releases
+  api_key:
+      secure: ""
+  file: 
+  - inlets
+  - inlets-darwin
+  - inlets-armhf
+  - inlets-arm64
+  - inlets.sha256
+  - inlets-darwin.sha256
+  - inlets-armhf.sha256
+  - inlets-arm64.sha256
+  skip_cleanup: true
+  on:
+    tags: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,11 @@ COPY parse_upstream.go  .
 ARG GIT_COMMIT
 ARG VERSION
 
-RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.GitCommit=${GIT_COMMIT} -X main.Version=${VERSION}" -a -installsuffix cgo -o /usr/bin/inlets
+RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
+
+RUN CGO_ENABLED=0 go build -ldflags "-s -w \
+      -X main.GitCommit=${GIT_COMMIT} -X main.Version=${VERSION}" \
+      -a -installsuffix cgo -o /usr/bin/inlets
 
 FROM alpine:3.9
 RUN apk add --force-refresh ca-certificates

--- a/Dockerfile.redist
+++ b/Dockerfile.redist
@@ -1,0 +1,48 @@
+FROM golang:1.11 as builder
+
+WORKDIR /go/src/github.com/alexellis/inlets
+
+COPY vendor            vendor
+COPY pkg                pkg
+COPY main.go            .
+COPY parse_upstream.go  .
+
+
+# Run a gofmt and exclude all vendored code.
+RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
+
+ARG GIT_COMMIT
+ARG VERSION
+
+RUN CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w \
+        -X main.GitCommit=${GIT_COMMIT} \
+        -X main.GitCommit=${VERSION}" \
+        -a -installsuffix cgo -o inlets \
+ && CGO_ENABLED=0 GOOS=darwin go build --ldflags "-s -w \
+        -X main.GitCommit=${GIT_COMMIT} \
+        -X main.GitCommit=${VERSION}" \
+        -a -installsuffix cgo -o inlets-darwin \
+ && CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build --ldflags "-s -w \
+        -X main.GitCommit=${GIT_COMMIT} \
+        -X main.GitCommit=${VERSION}" \
+        -a -installsuffix cgo -o inlets-armhf \
+ && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build --ldflags "-s -w \
+        -X main.GitCommit=${GIT_COMMIT} \
+        -X main.GitCommit=${VERSION}" \
+        -a -installsuffix cgo -o inlets-arm64
+
+FROM alpine:3.8
+
+RUN apk --no-cache add ca-certificates git
+
+WORKDIR /root/
+
+COPY --from=builder /go/src/github.com/alexellis/inlets/inlets                .
+COPY --from=builder /go/src/github.com/alexellis/inlets/inlets-darwin         .
+COPY --from=builder /go/src/github.com/alexellis/inlets/inlets-armhf          .
+COPY --from=builder /go/src/github.com/alexellis/inlets/inlets-arm64          .
+
+ENV PATH=$PATH:/root/
+
+CMD ["inlets"]
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+export eTAG="latest"
+echo $1
+if [ $1 ] ; then
+  eTAG=$1
+fi
+
+Version=$(git describe --tags --dirty)
+GitCommit=$(git rev-parse HEAD)
+
+
+echo Building alexellis2/inlets:$eTAG
+
+docker build --build-arg VERSION=$Version --build-arg GIT_COMMIT=$GitCommit -t alexellis2/inlets:$eTAG . && \
+ docker create --name inlets alexellis2/inlets:$eTAG && \
+ docker cp inlets:/root/inlets . && \
+ docker rm -f inlets

--- a/build_redist.sh
+++ b/build_redist.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+export eTAG="latest"
+echo $1
+if [ $1 ] ; then
+  eTAG=$1
+fi
+
+Version=$(git describe --tags --dirty)
+GitCommit=$(git rev-parse HEAD)
+
+
+echo Building alexellis2/inlets:$eTAG
+
+docker build --build-arg VERSION=$Version --build-arg GIT_COMMIT=$GitCommit -t alexellis2/inlets:$eTAG . -f Dockerfile.redist && \
+ docker create --name inlets alexellis2/inlets:$eTAG && \
+ docker cp inlets:/root/inlets . && \
+ docker cp inlets:/root/inlets-darwin . && \
+ docker cp inlets:/root/inlets-armhf . && \
+ docker cp inlets:/root/inlets-arm64 . && \
+ docker rm -f inlets

--- a/ci/hashgen.sh
+++ b/ci/hashgen.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+for f in inlets*; do shasum -a 256 $f > $f.sha256; done


### PR DESCRIPTION
Signed-off-by: Swarvanu Sengupta <swarvanusg@gmail.com>

## Description
Provide release CI script for Travis to automate the Github release process 
* Publish and save binary.  
* push a Docker image.  
* Go fmt check

**Things considered as Non Goal** 
* Windows release as there is a open issue 
* Golang Tests
* Integration Test 

Fixes: #31  

## How Has This Been Tested?
The main command with script are tested with
```sh
make
make build
make build_redist
```
Other travis call such as
`./ci/hashgen.sh`   
and
```sh
docker tag $DOCKER_NS/inlets:latest $DOCKER_NS/inlets:$TRAVIS_TAG
echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
docker push $DOCKER_NS/inlets:$TRAVIS_TAG;
```
are tested manually 

## How are existing users impacted? What migration steps/scripts do we need?
> Build needs Docker to be available locally


## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests