### PR TITLE
Change the exe location in the service file

### DIFF
--- a/hack/inlets.service
+++ b/hack/inlets.service
@@ -8,7 +8,7 @@ Restart=always
 RestartSec=1
 StartLimitInterval=0
 EnvironmentFile=/etc/default/inlets
-ExecStart=/usr/bin/inlets -server=true -port=80 -token="${AUTHTOKEN}"
+ExecStart=/usr/local/bin/inlets -server=true -port=80 -token="${AUTHTOKEN}"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
Moves the exe location in the service definition to match the location installed to by the get script.
Fixes #40

## How Has This Been Tested?


## How are existing users impacted? What migration steps/scripts do we need?
None - bugfix

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
