### PR TITLE
Use make to make artifacts instead of phonies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 - docker
 script:
 - make docker
-- make dist
+- make build
 
 after_success:
   - make docker-login

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,13 @@ COPY .git               .git
 COPY vendor             vendor
 COPY pkg                pkg
 COPY main.go            .
+COPY Makefile           .
 COPY parse_upstream.go  .
 
 ARG GIT_COMMIT
 ARG VERSION
 
-RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.GitCommit=${GIT_COMMIT} -X main.Version=${VERSION}" -a -installsuffix cgo -o /usr/bin/inlets
+RUN make install
 
 FROM alpine:3.9
 RUN apk add --force-refresh ca-certificates
@@ -21,7 +22,7 @@ RUN addgroup -S app && adduser -S -g app app \
   && mkdir -p /home/app || : \
   && chown -R app /home/app
 
-COPY --from=build /usr/bin/inlets /usr/bin/
+COPY --from=build /usr/local/bin/inlets /usr/bin/
 WORKDIR /home/app
 
 USER app

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,45 @@ Version := $(shell git describe --tags --dirty)
 GitCommit := $(shell git rev-parse HEAD)
 LDFLAGS := "-s -w -X main.Version=$(Version) -X main.GitCommit=$(GitCommit)"
 
+BINARIES := inlets inlets-darwin inlets-armhf inlets-arm64
+ALL_BINARIES := $(addprefix bin/,$(BINARIES))
+
+PREFIX := /usr/local
+BINDIR := $(PREFIX)/bin
+
 .PHONY: all
 all: docker
 
+.PHONY: clean
+clean:
+	$(RM) -r bin/
+
+.PHONY: build
+build: $(ALL_BINARIES)
+
+# TODO: kept for backwards compat, but is now redundant with the build target
 .PHONY: dist
-dist:
-	CGO_ENABLED=0 GOOS=linux go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inlets
-	CGO_ENABLED=0 GOOS=darwin go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inlets-darwin
-	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inlets-armhf
+dist: $(ALL_BINARIES)
+
+.PHONY: install
+install: bin/inlets
+	install -d $(BINDIR)
+	install -p -m 0755 $^ $(BINDIR)
+
+.PHONY: uninstall
+uninstall:
+	$(RM) $(PREFIX)$(BINDIR)/inlets
+
+bin/inlets:
+	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o $@
+
+bin/inlets-darwin:
+	CGO_ENABLED=0 GOOS=darwin go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o $@
+
+bin/inlets-armhf:
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o $@
+
+bin/inlets-arm64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags $(LDFLAGS) -a -installsuffix cgo -o bin/inlets-arm64
 
 .PHONY: docker


### PR DESCRIPTION
## Description
Make is better when used to make artifacts so we can use it here to
actually make the artifacts instead of relying on a single target to
make everything. Changes the travis yaml and Dockerfile to utilize
the targets as well.

Also gives the option of having `bin/inlets` produce an artifact that
could be native to your system (instead of having a specific target to
produce a darwin specific binary).

There's also some niceties thrown in like having the some basic make
targets like `clean`, `build`, `install`, and `uninstall`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
#!/usr/bin/env bash
set -e
make build
make dist
make install && make uninstall
make clean
```

## How are existing users impacted? What migration steps/scripts do we need?

Current users are not affected, the `dist` target does still exist and functions as it did before, but it should be removed in the future in favor of the `build` target.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests

<details> 
<summary> Cute gif of an animal just becase </summary>

![koala](https://media.giphy.com/media/PqSbSRO7n97na/giphy.gif)

</details>