### PR TITLE
Produce SHA hashes of each binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ after_success:
   - make docker-login
   - make push
 
+before_deploy:
+  - ./ci/hashgen.sh
+
 deploy:
   provider: releases
   api_key:
@@ -23,7 +26,10 @@ deploy:
     - ./bin/inlets-darwin
     - ./bin/inlets-armhf
     - ./bin/inlets-arm64
+    - ./bin/inlets.sha256
+    - ./bin/inlets-darwin.sha256
+    - ./bin/inlets-armhf.sha256
+    - ./bin/inlets-arm64.sha256
   skip_cleanup: true
   on:
     tags: true
-

--- a/ci/hashgen.sh
+++ b/ci/hashgen.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+for f in bin/inlets*; do shasum -a 256 $f > $f.sha256; done


### PR DESCRIPTION
## Description

This approacth is the same as openfaas/faas-cli.
Also updated travis to be picked up on the releases page.

Closes #44 

Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
$ ./ci/hashgen.sh 
```

Results:

```bash
$ ll bin
total 57072
-rwxr-xr-x  1 ken.fukuyama  staff   7.2M Mar 12 18:03 inlets
-rwxr-xr-x  1 ken.fukuyama  staff   6.7M Mar 12 18:04 inlets-arm64
-rw-r--r--  1 ken.fukuyama  staff    83B Mar 12 18:04 inlets-arm64.sha256
-rwxr-xr-x  1 ken.fukuyama  staff   6.1M Mar 12 18:03 inlets-armhf
-rw-r--r--  1 ken.fukuyama  staff    83B Mar 12 18:04 inlets-armhf.sha256
-rwxr-xr-x  1 ken.fukuyama  staff   7.9M Mar 12 18:03 inlets-darwin
-rw-r--r--  1 ken.fukuyama  staff    84B Mar 12 18:04 inlets-darwin.sha256
-rw-r--r--  1 ken.fukuyama  staff    77B Mar 12 18:04 inlets.sha256
```

## How are existing users impacted? What migration steps/scripts do we need?

None.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
