### PR TITLE
Initial ping/pong attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ curl -sLS https://get.inlets.dev | sh
 curl -sLS https://get.inlets.dev | sudo sh
 ```
 
-Binaries for Linux, Darwin (MacOS) and armhf are made available via the [releases page](https://github.com/alexellis/inlets/releases)
+Binaries for Linux, Darwin (MacOS) and armhf are made available via the [releases page](https://github.com/alexellis/inlets/releases). You will also find SHA checksums available if you want to verify your download.
 
 ## Test it out
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"log"
 	"strings"
+	"time"
 
 	"github.com/alexellis/inlets/pkg/client"
 	"github.com/pkg/errors"
@@ -14,6 +15,7 @@ func init() {
 	clientCmd.Flags().StringP("remote", "r", "127.0.0.1:8000", "server address i.e. 127.0.0.1:8000")
 	clientCmd.Flags().StringP("upstream", "u", "", "upstream server i.e. http://127.0.0.1:3000")
 	clientCmd.Flags().StringP("token", "t", "", "token for authentication")
+	clientCmd.Flags().DurationP("ping", "p", time.Second*10, "ping internal")
 }
 
 type UpstreamParser interface {
@@ -59,11 +61,11 @@ Note: You can pass the --token argument followed by a token value to both the se
 func runClient(cmd *cobra.Command, _ []string) error {
 	upstream, err := cmd.Flags().GetString("upstream")
 	if err != nil {
-		return errors.Wrap(err, "failed to get 'upstream' value.")
+		return errors.Wrap(err, "failed to get 'upstream' value")
 	}
 
 	if len(upstream) == 0 {
-		return errors.New("upstream is missing in the client argument.")
+		return errors.New("upstream is missing in the client argument")
 	}
 
 	argsUpstreamParser := ArgsUpstreamParser{}
@@ -82,10 +84,16 @@ func runClient(cmd *cobra.Command, _ []string) error {
 		return errors.Wrap(err, "failed to get 'token' value.")
 	}
 
+	pingDuration, err := cmd.Flags().GetDuration("ping")
+	if err != nil {
+		return errors.Wrap(err, "failed to get 'ping' value.")
+	}
+
 	inletsClient := client.Client{
-		Remote:      remote,
-		UpstreamMap: upstreamMap,
-		Token:       token,
+		Remote:           remote,
+		UpstreamMap:      upstreamMap,
+		Token:            token,
+		PingWaitDuration: pingDuration,
 	}
 
 	if err := inletsClient.Connect(); err != nil {

--- a/pkg/transport/pingpong.go
+++ b/pkg/transport/pingpong.go
@@ -1,0 +1,76 @@
+package transport
+
+import (
+	"log"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+type WebsocketConn struct {
+	sync.RWMutex
+	conn             *websocket.Conn
+	PingWaitDuration time.Duration
+}
+
+func NewWebsocketConn(conn *websocket.Conn, pingWaitDuration time.Duration) *WebsocketConn {
+	w := WebsocketConn{
+		conn:             conn,
+		PingWaitDuration: pingWaitDuration,
+	}
+	w.setupDeadline()
+
+	return &w
+}
+
+func (w *WebsocketConn) WriteMessage(messageType int, data []byte) error {
+	w.Lock()
+	w.conn.SetWriteDeadline(time.Now().Add(w.PingWaitDuration))
+	w.Unlock()
+	return w.conn.WriteMessage(messageType, data)
+}
+
+func (w *WebsocketConn) setupDeadline() {
+	log.Printf("Ping duration: %fs", w.PingWaitDuration.Seconds())
+	w.conn.SetReadDeadline(time.Now().Add(w.PingWaitDuration))
+	w.conn.SetPongHandler(func(string) error {
+		log.Printf("PongHandler. Extend deadline.")
+
+		newDeadline := time.Now().Add(w.PingWaitDuration)
+		return w.conn.SetReadDeadline(newDeadline)
+	})
+
+	w.conn.SetPingHandler(func(string) error {
+		log.Printf("PingHandler. Send pong")
+		w.Lock()
+		w.conn.WriteControl(websocket.PongMessage, []byte(""), time.Now().Add(time.Second))
+		w.Unlock()
+		return w.conn.SetReadDeadline(time.Now().Add(w.PingWaitDuration))
+	})
+
+}
+
+func (w *WebsocketConn) LocalAddr() net.Addr {
+	return w.conn.LocalAddr()
+}
+
+func (w *WebsocketConn) ReadMessage() (messageType int, p []byte, err error) {
+	return w.conn.ReadMessage()
+}
+
+func (w *WebsocketConn) Ping() error {
+	w.Lock()
+	defer w.Unlock()
+	if err := w.conn.WriteControl(websocket.PingMessage, []byte(""), time.Now().Add(time.Second)); err != nil {
+		log.Println("Error sendind ping")
+		return err
+	}
+	log.Println("Ping sent")
+	return nil
+}
+
+// func (w *WebsocketConn) NextReader() (messageType int, r io.Reader, err error) {
+// 	return w.conn.NextReader()
+// }


### PR DESCRIPTION
## Description

Attempting to resolve #42 by sending continual ping from each
client to keep connection alive.

Signed-off-by: Alex Ellis <alexellis2@gmail.com>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

By running a client / server and monitoring output.

```
go build && ./inlets client --remote=localhost:80 --upstream=http://192.168.0.35:8080
2019/03/12 13:18:02 Upstream:  => http://192.168.0.35:8080
2019/03/12 13:18:02 connecting to ws://localhost:80/tunnel with ping=10s
2019/03/12 13:18:02 Ping duration: 10.000000s
2019/03/12 13:18:02 Connected to websocket: [::1]:57520
2019/03/12 13:18:02 Writing pings
2019/03/12 13:18:11 Ping sent
2019/03/12 13:18:11 PongHandler. Extend deadline.
```

The new flag `--ping` is also working with the default and override:

```
go build && ./inlets client --remote=localhost:80 --upstream=http://192.168.0.35:8080 --p
ing 1m
2019/03/12 13:18:20 Upstream:  => http://192.168.0.35:8080
2019/03/12 13:18:20 connecting to ws://localhost:80/tunnel with ping=1m0s
```

## How are existing users impacted? What migration steps/scripts do we need?

Upgrading would be helpful to prevent timeouts

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
