### PR TITLE
Add brew install instructions for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ Unlike HTTP 1.1 which follows a synchronous request/response model websockets us
 * ~~There is no timeout for when the tunnel is disconnected~~ timeout can be configured via args on the server
 * ~~The upstream URL has to be configured on both server and client until a discovery or service advertisement mechanism is added~~ advertise on the client
 
-### Get `inlets`
+### Get started: Install the CLI
 
-Run this command:
+You can install the CLI with a `curl` utility script, `brew` or by downloading the binary from the releases page. Once installed you'll get the `inlets` command.
+
+Utility script with `curl`:
 
 ```bash
 # Install to local directory
@@ -66,6 +68,12 @@ curl -sLS https://get.inlets.dev | sh
 
 # Install to /usr/local/bin/
 curl -sLS https://get.inlets.dev | sudo sh
+```
+
+Via `brew`:
+
+```bash
+brew install inlets
 ```
 
 Binaries for Linux, Darwin (MacOS) and armhf are made available via the [releases page](https://github.com/alexellis/inlets/releases). You will also find SHA checksums available if you want to verify your download.


### PR DESCRIPTION
## Description
This PR adds instructions on installation using `brew` following the merge of the `inlets` formula into homebrew-core.

https://github.com/Homebrew/homebrew-core/pull/38235

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on local OSX box.

## How are existing users impacted? What migration steps/scripts do we need?
New functionality, no impact to existing users.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
