### PR TITLE
Fix unable to lookup registered host

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -48,7 +48,7 @@ func (r *Router) Lookup(req *http.Request) *Route {
 	r.RLock()
 	defer r.RUnlock()
 
-	targets := r.domains[req.URL.Host]
+	targets := r.domains[req.Host]
 	if len(targets) == 0 {
 		targets = r.domains[""]
 	}


### PR DESCRIPTION
## Description

I setup inlets but it always returns 503 error event I specify a hostname.

According [StackOverflow](https://stackoverflow.com/questions/42921567/what-is-the-difference-between-host-and-url-host-for-golang-http-request) it should replace `req.URL.Host` to `req.Host` and it will be able to use `Host` HTTP request header.

## How Has This Been Tested?

Just compile it on localhost and check it works well.


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
