### PR TITLE
Add buildkit support for cross-platform docker image publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ after_success:
   - make docker-login
   - make buildkitd
   - make docker-buildkit-images
+  - make docker-buildkit-push-manifests
 
 before_deploy:
   - ./ci/hashgen.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: xenial
 language: go
 
 go:
@@ -6,13 +7,20 @@ go:
 
 services:
 - docker
+
+addons:
+   apt:
+     packages:
+       - docker-ce
+
 script:
 - make docker
 - make dist
 
 after_success:
   - make docker-login
-  - make push
+  - make buildkitd
+  - make docker-buildkit-images
 
 before_deploy:
   - ./ci/hashgen.sh

--- a/Dockerfile.multi-arch
+++ b/Dockerfile.multi-arch
@@ -28,27 +28,13 @@ RUN CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH GOARM=${VARIANT_WITH_V//v} \
     -ldflags "-s -w -X main.GitCommit=${GIT_COMMIT} -X main.Version=${VERSION}" \
     -a -installsuffix cgo -o /usr/bin/inlets
 
-# Docker buildkit will uses matching TARGET platform
-FROM alpine:3.9 AS docker-image
-RUN apk add --force-refresh ca-certificates
+# Stage 2: Build the runtime image
+FROM --platform=$TARGETPLATFORM alpine:3.9 AS docker-image
 
-# Add non-root user
-RUN addgroup -S app && adduser -S -g app app \
-  && mkdir -p /home/app || : \
-  && chown -R app /home/app
-
-COPY --from=build /usr/bin/inlets /usr/bin/
-WORKDIR /home/app
-
-USER app
-EXPOSE 80
-
-ENTRYPOINT ["inlets"]
-CMD ["--help"]
-
-# Duplicate stage due to armhf not being in alpine:3.9 image manifest
-FROM arm32v6/alpine:3.9 AS docker-image-arm32v6
-RUN apk add --force-refresh ca-certificates
+# Add certificate authority certs
+RUN apk add --no-cache --update \
+        ca-certificates \
+  && rm -rf /var/cache/apk/*
 
 # Add non-root user
 RUN addgroup -S app && adduser -S -g app app \

--- a/Dockerfile.multi-arch
+++ b/Dockerfile.multi-arch
@@ -28,8 +28,26 @@ RUN CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH GOARM=${VARIANT_WITH_V//v} \
     -ldflags "-s -w -X main.GitCommit=${GIT_COMMIT} -X main.Version=${VERSION}" \
     -a -installsuffix cgo -o /usr/bin/inlets
 
-# Will use the matching TARGET platform
+# docker build/buildkit uses the matching TARGET platform
 FROM alpine:3.9
+RUN apk add --force-refresh ca-certificates
+
+# Add non-root user
+RUN addgroup -S app && adduser -S -g app app \
+  && mkdir -p /home/app || : \
+  && chown -R app /home/app
+
+COPY --from=build /usr/bin/inlets /usr/bin/
+WORKDIR /home/app
+
+USER app
+EXPOSE 80
+
+ENTRYPOINT ["inlets"]
+CMD ["--help"]
+
+# duplicated phase since armhf not found in the alpine:3.9 image manifest
+FROM arm32v6/alpine:3.9
 RUN apk add --force-refresh ca-certificates
 
 # Add non-root user

--- a/Dockerfile.multi-arch
+++ b/Dockerfile.multi-arch
@@ -2,7 +2,7 @@
 # BUILD* means the platform of the node doing the build
 # TARGET* is the target platform of the build job
 
-# this stage is fixed to worker platform (linux/amd64 in this case)
+# build stage is affixed to worker platform (linux/amd64)
 FROM --platform=$BUILDPLATFORM golang:1.10-alpine AS build
 
 # expose the values to the stage
@@ -12,7 +12,7 @@ ARG TARGETVARIANT
 ARG GIT_COMMIT
 ARG VERSION
 
-# configure go to use target configuration
+# Configure golang to use target configuration
 ENV GOOS=$TARGETOS GOARCH=$TARGETARCH VARIANT_WITH_V=$TARGETVARIANT
 
 WORKDIR /go/src/github.com/alexellis/inlets
@@ -28,8 +28,8 @@ RUN CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH GOARM=${VARIANT_WITH_V//v} \
     -ldflags "-s -w -X main.GitCommit=${GIT_COMMIT} -X main.Version=${VERSION}" \
     -a -installsuffix cgo -o /usr/bin/inlets
 
-# docker build/buildkit uses the matching TARGET platform
-FROM alpine:3.9
+# Docker buildkit will uses matching TARGET platform
+FROM alpine:3.9 AS docker-image
 RUN apk add --force-refresh ca-certificates
 
 # Add non-root user
@@ -46,8 +46,8 @@ EXPOSE 80
 ENTRYPOINT ["inlets"]
 CMD ["--help"]
 
-# duplicated phase since armhf not found in the alpine:3.9 image manifest
-FROM arm32v6/alpine:3.9
+# Duplicate stage due to armhf not being in alpine:3.9 image manifest
+FROM arm32v6/alpine:3.9 AS docker-image-arm32v6
 RUN apk add --force-refresh ca-certificates
 
 # Add non-root user

--- a/Dockerfile.multi-arch
+++ b/Dockerfile.multi-arch
@@ -1,0 +1,47 @@
+# BUILD* and TARGET* args are filled automatically
+# BUILD* means the platform of the node doing the build
+# TARGET* is the target platform of the build job
+
+# this stage is fixed to worker platform (linux/amd64 in this case)
+FROM --platform=$BUILDPLATFORM golang:1.10-alpine AS build
+
+# expose the values to the stage
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG GIT_COMMIT
+ARG VERSION
+
+# configure go to use target configuration
+ENV GOOS=$TARGETOS GOARCH=$TARGETARCH VARIANT_WITH_V=$TARGETVARIANT
+
+WORKDIR /go/src/github.com/alexellis/inlets
+
+COPY .git               .git
+COPY vendor             vendor
+COPY pkg                pkg
+COPY cmd                cmd
+COPY main.go            .
+
+RUN CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH GOARM=${VARIANT_WITH_V//v} \
+    go build \
+    -ldflags "-s -w -X main.GitCommit=${GIT_COMMIT} -X main.Version=${VERSION}" \
+    -a -installsuffix cgo -o /usr/bin/inlets
+
+# Will use the matching TARGET platform
+FROM alpine:3.9
+RUN apk add --force-refresh ca-certificates
+
+# Add non-root user
+RUN addgroup -S app && adduser -S -g app app \
+  && mkdir -p /home/app || : \
+  && chown -R app /home/app
+
+COPY --from=build /usr/bin/inlets /usr/bin/
+WORKDIR /home/app
+
+USER app
+EXPOSE 80
+
+ENTRYPOINT ["inlets"]
+CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ ifneq ($(BUILDKITD_CONTAINER_RUNNING),$(BUILDKITD_CONTAINER_NAME))
           --addr $(BUILDKIT_HOST) \
           --oci-worker-platform linux/amd64 \
           --oci-worker-platform linux/arm64 \
-          --oci-worker-platform linux/armhf
+          --oci-worker-platform linux/armhf \
+          --oci-worker-platform linux/arm32v6
 	sudo docker cp $(BUILDKITD_CONTAINER_NAME):/usr/bin/buildctl /usr/bin/
 endif
 endif

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,22 @@ GitCommit := $(shell git rev-parse HEAD)
 LDFLAGS := "-s -w -X main.Version=$(Version) -X main.GitCommit=$(GitCommit)"
 PLATFORM := $(shell ./hack/platform-tag.sh)
 
+BUILDKIT_HOST ?= tcp://0.0.0.0:1234
+BUILDKITD_CONTAINER_NAME ?= buildkitd
+BUILDKITD_CONTAINER_STOPPED := $(shell docker ps --filter name=$(BUILDKITD_CONTAINER_NAME) --filter status=exited --format='{{.Names}}' 2>/dev/null)
+BUILDKITD_CONTAINER_RUNNING := $(shell docker ps --filter name=$(BUILDKITD_CONTAINER_NAME) --filter status=running --format='{{.Names}}' 2>/dev/null)
+
+BUILDKIT_COMMON_ARGS =  --progress=plain
+BUILDKIT_COMMON_ARGS += --frontend dockerfile.v0
+BUILDKIT_COMMON_ARGS += --local dockerfile=.
+BUILDKIT_COMMON_ARGS += --local context=.
+BUILDKIT_COMMON_ARGS += --opt filename=./Dockerfile.multi-arch
+BUILDKIT_COMMON_ARGS += --opt build-arg:GIT_COMMIT=$(GitCommit)
+BUILDKIT_COMMON_ARGS += --opt build-arg:VERSION=$(Version)
+
+DOCKER_HUB_REPO ?= alexellis2/inlets
+BUILDKIT_PUSH_TO_REPO ?= true
+
 .PHONY: all
 all: docker
 
@@ -15,7 +31,40 @@ dist:
 
 .PHONY: docker
 docker:
-	docker build --build-arg Version=$(Version) --build-arg GIT_COMMIT=$(GitCommit) -t alexellis2/inlets:$(Version)$(PLATFORM) .
+	docker build --build-arg Version=$(Version) --build-arg GIT_COMMIT=$(GitCommit) -t $(DOCKER_HUB_REPO):$(Version)$(PLATFORM) .
+
+
+.PHONY: buildkitd
+buildkitd:
+	docker run --privileged linuxkit/binfmt:v0.7
+ifeq (tcp://0.0.0.0:1234,$(findstring tcp://0.0.0.0:1234,$(BUILDKIT_HOST)))
+ifeq ($(BUILDKITD_CONTAINER_STOPPED),$(BUILDKITD_CONTAINER_NAME))
+	@echo "Removing exited buildkitd container"
+	docker rm $(BUILDKITD_CONTAINER_NAME)
+endif
+ifneq ($(BUILDKITD_CONTAINER_RUNNING),$(BUILDKITD_CONTAINER_NAME))
+	@echo "Starting buildkitd container"
+	docker run -d --privileged -p 1234:1234 --name $(BUILDKITD_CONTAINER_NAME) moby/buildkit:latest \
+          --addr $(BUILDKIT_HOST) \
+          --oci-worker-platform linux/amd64 \
+          --oci-worker-platform linux/arm64 \
+          --oci-worker-platform linux/armhf
+	docker cp $(BUILDKITD_CONTAINER_NAME):/usr/bin/buildctl /usr/bin/
+endif
+endif
+
+# push=true assumed logged into registry
+.PHONY: docker-buildkit-images
+docker-buildkit-images:
+	BUILDKIT_HOST=$(BUILDKIT_HOST) buildctl build $(BUILDKIT_COMMON_ARGS) \
+          --opt platform=linux/amd64 \
+          --output type=image,name=docker.io/$(DOCKER_HUB_REPO):$(Version)-amd64,push=$(BUILDKIT_PUSH_TO_REPO)
+	BUILDKIT_HOST=$(BUILDKIT_HOST) buildctl build $(BUILDKIT_COMMON_ARGS) \
+          --opt platform=linux/arm64 \
+          --output type=image,name=docker.io/$(DOCKER_HUB_REPO):$(Version)-arm64,push=$(BUILDKIT_PUSH_TO_REPO)
+	BUILDKIT_HOST=$(BUILDKIT_HOST) buildctl build $(BUILDKIT_COMMON_ARGS) \
+          --opt platform=linux/armhf \
+          --output type=image,name=docker.io/$(DOCKER_HUB_REPO):$(Version)-armhf,push=$(BUILDKIT_PUSH_TO_REPO)
 
 .PHONY: docker-login
 docker-login:
@@ -23,4 +72,4 @@ docker-login:
 
 .PHONY: push
 push:
-	docker push alexellis2/inlets:$(Version)$(PLATFORM)
+	docker push $(DOCKER_HUB_REPO):$(Version)$(PLATFORM)

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ ifneq ($(BUILDKITD_CONTAINER_RUNNING),$(BUILDKITD_CONTAINER_NAME))
           --oci-worker-platform linux/amd64 \
           --oci-worker-platform linux/arm64 \
           --oci-worker-platform linux/armhf
-	docker cp $(BUILDKITD_CONTAINER_NAME):/usr/bin/buildctl /usr/bin/
+	sudo docker cp $(BUILDKITD_CONTAINER_NAME):/usr/bin/buildctl /usr/bin/
 endif
 endif
 


### PR DESCRIPTION
## Description

PR for implemention of #60 multi-arch docker image publishing

- Added rules to Makefile (and invoke in .travis.yml)

  1. launch a buildkitd

  2. build cross-platform docker container images (`amd64`, `arm64`, `armhf`) and tag

  3. Tag archs and latest. Create and push multi-arch image using `docker manifest`. Tags for the pushed images are set in the Makefile

- Created `Dockerfile.multi-arch`

  - works like standard project Dockerfile, but adds cross-platform support
     1. `go build` builds appropriate arch in build stage
     2. `alpine`-based image is created adding `ca-certificates` and the app user.

TODO

 - [X] Get signoff on docker image platform tag names (Mooted with 'latest' tag)
 - [X] annotate image manifests and support multi-arch image tags
 - [X] ~~replace Dockerfile with Dockerfile.multi-arch?~~

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change  affects other areas of the code, etc. -->

```bash
# run as root user on an Ubuntu 18.04 machine
make buildkitd
BUILDKIT_PUSH_TO_REPO=false make docker-buildkit-images
```

```shell
# run as root on an ubuntu VM
make buildkitd
DOCKER_HUB_REPO=dpcrook/inlets make docker-buildkit-images
DOCKER_HUB_REPO=dpcrook/inlets make docker-buildkit-push-manifests
```

With this PR, on each of the supported architectures, something like the following will work:

```shell
$ sudo docker run -i dpcrook/inlets:latest
$ uname -m
aarch64
```
Also works on each of support platform using simple image tag `:Version` (no `-{arch}` necessary)
```shell
$ docker run -i dpcrook/inlets:2.0.3-5-gf88adc4
$ uname -m
armv7l
```

## How are existing users impacted? What migration steps/scripts do we need?

This PR will affect the travis/release phase for docker images. 
 - Adds support for building cross-platform docker images, including on travis-ci.

## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [X] added unit tests (implicit in travis-ci builds and deploys)
