### PR TITLE
Fix handling multiple upstreams

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -31,7 +31,7 @@ func (c *Client) Connect() error {
 	headers := http.Header{}
 	headers.Set(transport.InletsHeader, uuid.Formatter(uuid.NewV4(), uuid.FormatHex))
 	for k, v := range c.UpstreamMap {
-		headers.Set(transport.UpstreamHeader, fmt.Sprintf("%s=%s", k, v))
+		headers.Add(transport.UpstreamHeader, fmt.Sprintf("%s=%s", k, v))
 	}
 	if c.Token != "" {
 		headers.Add("Authorization", "Bearer "+c.Token)


### PR DESCRIPTION
## Description
The header was set using `header.Set()` which led to overriding the headers for multiple upstreams, such that only the last one in the `--upstream` arguments is present in the header upstream. Fixing #67.

## How Has This Been Tested?
Simple fix, tested with re-running the client locally. I can provide more robust testing if needed.
Run inlet client with multiple `--upstream` arguments. They successfully print, and thus are stored in the map correctly, i.e.
```
2019/06/05 13:29:17 Upstream: test.example.com => http://127.0.0.1:12435
2019/06/05 13:29:17 Upstream: test2.example.com => http://127.0.0.1:54321
```
but when the headers are printed, only one is included:
```
map[X-Inlets-Id:[XXXXXXXXXXXXXXXXXXXXXX] X-Inlets-Upstream:
[test2.example.com=http://127.0.0.1:54321] Authorization:[Bearer XXXXXXXXXXXXXXX]]
```
after fix, both will be included and serve from both.

## How are existing users impacted? What migration steps/scripts do we need?
Bug fix, should provide intended behavior for multiple upstreams. No migrations needed. I did not include unit tests, but can if they are needed.
