### PR TITLE
Add auth token output to DO provision script

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,26 @@ You can get a free domain-name with a .tk / .ml or .ga TLD from https://www.free
 
 ##### Digital Ocean
 
-If you're a DigitalOcean user and use `doctl` then you can provision a host with [./hack/provision-digitalocean.sh](./hack/provision-digitalocean.sh).  Please ensure you have configured `droplet.create.ssh-keys` within your `~/.config/doctl/config.yaml`.
+If you're a DigitalOcean user and use `doctl` then you can provision a host with [./hack/provision-digitalocean.sh](./hack/provision-digitalocean.sh).  Please ensure you have configured `droplet.create.ssh-keys` within your `~/.config/doctl/config.yaml`.  You will need the IDs of the keys you wish to deploy onto the droplet, there can be obtained by using:
+
+```sh
+$ doctl compute ssh-key list
+
+ID          Name      FingerPrint
+12345678    MY_Key    f0:ce:d0:22:dd:56:97:03:c3:f1:64:a6:5a:3f:8d:53
+```
+Your chosen key IDs then need to be added to the droplet create section:
+```yaml
+droplet:
+  actions:
+    ...
+  backups:
+    ...
+  create:
+    ...
+    ssh-keys: [12345678]
+    ...
+```
 
 DigitalOcean will then email you the IP and root password for your new host. You can use it to log in and get your auth token, so that you can connect your client after that.
 

--- a/hack/provision-digitalocean.sh
+++ b/hack/provision-digitalocean.sh
@@ -26,11 +26,28 @@ then
 readfields=$(sed 's/,/ /g' <<<$FIELDS)
 read -r $readfields <<<"$dropletInfo"
 
-echo "=============================="
+sleep 40
+
+droplet_host_key=$(ssh-keyscan -t rsa ${PublicIPv4} 2> /dev/null)
+
+grep "${droplet_host_key}" ~/.ssh/known_hosts >/dev/null || {
+    ssh-keygen -R ${PublicIPv4} 2>/dev/null
+    echo ${droplet_host_key} >>  ~/.ssh/known_hosts
+}
+
+TOKEN="$(doctl compute ssh $ID --ssh-command 'cat /etc/default/inlets')"
+if [ $? -ne 0 ];
+then
+TOKEN="Unable to obtain Auth Token, please run: doctl compute ssh $ID --ssh-command 'cat /etc/default/inlets'"
+fi
+
+echo "============================================================"
 echo "Droplet: $Name has been created"
 echo "IP: $PublicIPv4"
 echo "Login: ssh root@$PublicIPv4"
-echo "=============================="
+echo "$TOKEN"
+echo "============================================================"
 echo "To destroy this droplet run: doctl compute droplet delete -f $ID"
+echo ""
 
 fi


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
Adds some additional steps to the DO provision script to remove the need for the user to log into the newly provisioned box to obtain the auth token.  There is a caveat here that host key checking is effectively over-ridden to smooth the process.  How desirable this may be is open to debate.
Updates the readme to expand on the DOCTL configuration steps.

## How Has This Been Tested?
```
$ ./hack/provision-digitalocean.sh 
Creating: inletsc367a83e
============================================================
Droplet: inletsc367a83e has been created
IP: 134.209.177.17
Login: ssh root@134.209.177.17
AUTHTOKEN=deaf9a5a2eb65c8170fa59ec7d5f92a46c218d8b
============================================================
To destroy this droplet run: doctl compute droplet delete -f 147830632
```

## How are existing users impacted? What migration steps/scripts do we need?
They aren't.  This should improve UX for future provisions on DO

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests