### PR TITLE
Added nginx configuration example to readme.

### DIFF
--- a/contrib/nginx.md
+++ b/contrib/nginx.md
@@ -1,0 +1,23 @@
+### Run behind nginx
+
+If you already have an existing nginx webserver running, you can proxy your inlets server through nginx. Simply create a new site configuration file. This example assumes inlets is running port 8000, the default port, but you can use any port number you'd like via `--port=` when starting the server:
+
+```
+server {
+    listen 80;
+
+    # Replace *.inlets.example.com with your own wildcard domain.
+    server_name *.inlets.example.com;
+
+    #Inlets proxy
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_http_version 1.1;
+        proxy_read_timeout 120s;
+        proxy_connect_timeout 120s;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+```
+You can even secure your connection with SSL via your own certificate, or via Letsencrypt!


### PR DESCRIPTION
## Description

I have added an explanation in the readme on how to configure nginx to proxy to inlets.

## How Has This Been Tested?
I have ran this configuration locally on my own raspberry pi. Attempted to connect over both ws:// and ws://

## How are existing users impacted? What migration steps/scripts do we need?

Not.

## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
