### PR TITLE
Add option to disable transport wrapping and keep CORS headers - fixes #75

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Feel free to open issues if you have comments, suggestions or contributions.
 * The default configuration uses websockets without SSL `ws://`, but to enable encryption you could enable SSL `wss://`
 * A timeout for requests can be configured via args on the server
 * ~~The upstream URL has to be configured on both server and client until a discovery or service advertisement mechanism is added~~ The client can advertise upstream URLs, which it can serve
+* The tunnel transport is wrapped by default which strips CORS headers from responses, but you can disable it with the `--disable-transport-wrapping` flag on the server
 
 ### Video demo
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -16,6 +16,7 @@ func init() {
 	serverCmd.Flags().StringP("token", "t", "", "token for authentication")
 	serverCmd.Flags().Bool("print-token", true, "prints the token in server mode")
 	serverCmd.Flags().StringP("token-from", "f", "", "read the authentication token from a file")
+	serverCmd.Flags().Bool("disable-transport-wrapping", false, "disable wrapping the transport that removes CORS headers for example")
 }
 
 // serverCmd represents the server sub command.
@@ -66,9 +67,16 @@ func runServer(cmd *cobra.Command, _ []string) error {
 		return errors.Wrap(err, "failed to get the 'port' value.")
 	}
 
+	disableWrapTransport, err := cmd.Flags().GetBool("disable-transport-wrapping")
+	if err != nil {
+		return errors.Wrap(err, "failed to get the 'disable-transport-wrapping' value.")
+	}
+
 	inletsServer := server.Server{
 		Port:  port,
 		Token: token,
+
+		DisableWrapTransport: disableWrapTransport,
 	}
 
 	inletsServer.Serve()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -20,6 +20,8 @@ type Server struct {
 	Token  string
 	router router.Router
 	server *remotedialer.Server
+
+	DisableWrapTransport bool
 }
 
 // Serve traffic
@@ -56,7 +58,7 @@ func (s *Server) proxy(w http.ResponseWriter, r *http.Request) {
 	u.Host = r.Host
 	u.Scheme = route.Scheme
 
-	httpProxy := proxy.NewUpgradeAwareHandler(&u, route.Transport, true, false, s)
+	httpProxy := proxy.NewUpgradeAwareHandler(&u, route.Transport, !s.DisableWrapTransport, false, s)
 	httpProxy.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
## Description

We have noticed that CORS related headers, like Access-Control-Allow-Origin, are stripped out of the responses. When investigating, I found that the k8s.io/apimachinery/pkg/util/proxy package's NewUpgradeAwareHandler does this on purpose, when the wrapTransport parameter is set to true - as is here in inlets.

This fixes #75 

## How Has This Been Tested?

When requesting a URL through the `server` that tunnels it through the `client` to an upstream, and if that upstream returns CORS headers, on the HTTP response received these headers are missing. With the new flag added when starting the `server`, those headers will be retained on the HTTP response.

## How are existing users impacted? What migration steps/scripts do we need?

The new flag is opt-in, existing users without configuration change (command line parameters) will have the same behavior as before.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests

I have not added any unit tests.