### PR TITLE
Update README.md `inlets client` example to pass `--token` correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ export REMOTE="127.0.0.1:8090"    # for testing inlets on your laptop, replace w
 export TOKEN="CLIENT-TOKEN-HERE"  # the client token is found on your VPS or on start-up of "inlets server"
 inlets client \
  --remote=$REMOTE \
- --upstream=http://127.0.0.1:3000
+ --upstream=http://127.0.0.1:3000 \
  --token $TOKEN
 ```
 


### PR DESCRIPTION
CLOSES #79 

Update `inlets client` shell example to pass `--token` with previous line ending in ` \`

## Description


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran example of `inlets client` as documented correctly in README and it now properly connects and passes token.

## How are existing users impacted? What migration steps/scripts do we need?
New users should now be able to follow readme and copy/paste examples will work.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
