### PR TITLE
Add AWS scripts to provision inlets exit nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,50 @@ If you have the Scaleway CLI installed you can provision a host with [./hack/pro
 
 Datacenters include: Paris and Amsterdam.
 
+##### AWS Lightsail
+
+AWS Lightsail is the lowest cost AWS VPS solution, nano instances cost 3.50 USD
+/ month. The script
+[./hack/provision-aws-lightsail-terraform.sh](./hack/provision-aws-lightsail-terraform.sh)
+will create an ssh keypair to be used on Lightsail then launch an instance and
+start the Inlets server. The bash script calls Terraform from the repository
+[mbacchi/inlets-aws-terraform](https://github.com/mbacchi/inlets-aws-terraform).
+By default Lightsail only allows port 22(SSH) and port 80(HTTP), so we bind
+Inlets to port 80. To open port 443(HTTPS) use the command `aws lightsail
+open-instance-public-ports --port-info fromPort=443,toPort=443,protocol=tcp
+--instance-name=INSTANCE_NAME` after the Terraform module has created the
+instance(at least until [Terraform PR
+8611](https://github.com/terraform-providers/terraform-provider-aws/pull/8611)
+allows this to be controlled via the Terraform AWS provider).
+
+Read more about the terraform module in the
+[README](https://github.com/mbacchi/inlets-aws-terraform/tree/master/terraform/lightsail).
+
+An example command to run this script would look like:
+
+```
+./provision-aws-lightsail-terraform.sh lightsail_keypair AWS_PROFILE us-east-2 http://127.0.0.1:4000
+```
+
+##### AWS EC2
+
+AWS EC2 is more expensive than Lightsail (and other VPS solutions,) but allows
+for more control and configurability of ports and IAM permissions. By default we
+use a `t2.micro` instance type for the lowest cost instance specifications. The
+bash script calls Terraform from the repository
+[mbacchi/inlets-aws-terraform](https://github.com/mbacchi/inlets-aws-terraform).
+It provides default settings that allow port 22(SSH) and port 8090(Inlets), but
+you could open additional ports if desired.
+
+Read more about the terraform module in the
+[README](https://github.com/mbacchi/inlets-aws-terraform/tree/master/terraform/ec2).
+
+An example command to run this script would look like:
+
+```
+./provision-aws-ec2-terraform.sh new-keypair-inlets AWS_PROFILE us-east-2 http://127.0.0.1:4000
+```
+
 #### Running over an SSH tunnel
 
 You can tunnel over SSH if you are not using a reverse proxy that enables SSL. This encrypts the traffic over the tunnel.

--- a/hack/provision-aws-ec2-terraform.sh
+++ b/hack/provision-aws-ec2-terraform.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+function check_prereqs() {
+    terraform=$(which terraform)
+    if [[ $? -ne 0 ]]; then
+        echo "Error: cannot locate the program 'terraform' in your path!"
+        exit 1
+    fi
+    sha256sum=$(which sha256sum)
+    if [[ $? -ne 0 ]]; then
+        echo "Error: cannot locate the program 'sha256sum' in your path!"
+        exit 1
+    fi
+}
+
+function git_clone() {
+    if [ -d inlets-aws-terraform ]; then
+        echo "Removing git repository directory inlets-aws-terraform"
+        rm -rf inlets-aws-terraform
+    fi
+    echo
+    echo "-----------------------------------------------------------------------------------"
+    echo
+    echo "Running 'git clone' command..."
+    git clone https://github.com/mbacchi/inlets-aws-terraform.git >/dev/null 2>&1
+    if [[ $? -ne 0 ]]; then
+        echo "Error: cannot clone the GitHub repository https://github.com/mbacchi/inlets-aws-terraform.git"
+        exit 1
+    else
+        echo
+        echo "Successfully cloned GitHub repository https://github.com/mbacchi/inlets-aws-terraform.git"
+    fi
+}
+
+function setup_exec_terraform() {
+    sed -i "s/KEYPAIR_NAME_HERE/${KEYPAIR_NAME}/" main.tf
+    grep ${KEYPAIR_NAME} main.tf >/dev/null 2>&1
+    if [[ $? -ne 0 ]]; then
+        echo "Error: could not substitute the keypair ${KEYPAIR_NAME} in main.tf line 64! Exiting..."
+        exit 1
+    fi
+
+    echo
+    echo "-----------------------------------------------------------------------------------"
+    echo
+    echo "Running 'terraform init' command..."
+    $terraform init 2>&1 | tee -a terraform.log
+    if [[ $? -ne 0 ]]; then
+        echo "Error: cannot run 'terraform init'. Look at log file 'terraform.$$.log' for errors."
+        exit 1
+    else
+        echo
+        echo "SUCCESS: 'terraform init' command successful."
+    fi
+
+    echo
+    echo "-----------------------------------------------------------------------------------"
+    echo
+    echo "Running 'terraform plan' command..."
+    token=$(head -c 16 /dev/urandom | sha256sum | cut -d" " -f1); \
+        $terraform plan -out=terraform_plan_inlets.$$.out  -var "token=$token" 2>&1 | tee -a terraform.log
+    if [[ $? -ne 0 ]]; then
+        echo "Error: cannot run 'terraform plan'. Look at log file 'terraform.$$.log' for errors."
+        exit 1
+    else
+        echo
+        echo "SUCCESS: 'terraform plan' command successful."
+    fi
+
+    echo
+    echo "-----------------------------------------------------------------------------------"
+    echo
+    echo "Running 'terraform apply' command..."
+    $terraform apply terraform_plan_inlets.$$.out 2>&1 | tee -a terraform.log
+    if [[ $? -ne 0 ]]; then
+        echo "Error: cannot run 'terraform apply'. Look at log file 'terraform.$$.log' for errors."
+        exit 1
+    else
+        echo
+        echo "SUCCESS: 'terraform apply' command successful."
+    fi
+}
+
+if [[ ${#} -lt "4" ]]; then
+    echo
+    echo "usage: $0 <aws_keypair_name> <aws_profile> <aws_region> <upstream_with_port>"
+    echo
+    echo "where:"
+    echo "<aws_keypair_name> is a previously created AWS keypair in your AWS user account (and which you have possession of the .pem file)"
+    echo "<aws_profile> is the AWS profile previously configured in your ~/.aws/credentials file"
+    echo "<aws_region> is the AWS region you will be deploying this EC2 instance"
+    echo "<upstream_with_port> is the application with the port running on 127.0.0.1 (example: https://127.0.0.1:4000)"
+    exit 1
+fi
+
+KEYPAIR_NAME="${1}"
+AWS_PROFILE="${2}"
+AWS_REGION="${3}"
+UPSTREAM="${4}"
+export AWS_PROFILE AWS_REGION
+
+check_prereqs
+git_clone
+
+save_dir=$(pwd)
+cd inlets-aws-terraform/terraform/ec2
+
+setup_exec_terraform
+
+TOKEN=$(cat terraform.log | grep -E "^inlets_token =" | sed -r 's/^inlets_token = (\w+)$/\1/')
+IP_ADDRESS=$(cat terraform.log | grep -E "^public_ip_address =" | sed -r 's/^public_ip_address = (.*)$/\1/')
+
+echo "-----------------------------------------------------------------------------------"
+echo
+echo
+echo "To connect to Inlets run the command:"
+echo
+echo "-----------------------------------------------------------------------------------"
+echo "inlets client  --remote=$IP_ADDRESS:8090 --upstream=$UPSTREAM --token $TOKEN"
+echo "-----------------------------------------------------------------------------------"
+
+echo
+echo
+echo "To tear down the terraform infrastructure, run the following commands:"
+echo
+echo "cd ${save_dir}/inlets-aws-terraform/terraform/ec2"
+echo "terraform destroy -var token=${TOKEN}"
+echo
+echo "You will be prompted to answer \"yes\" in order to actually remove the terraform resources."
+echo
+
+cd $save_dir

--- a/hack/provision-aws-lightsail-terraform.sh
+++ b/hack/provision-aws-lightsail-terraform.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+
+function check_prereqs() {
+    terraform=$(which terraform)
+    if [[ $? -ne 0 ]]; then
+        echo "Error: cannot locate the program 'terraform' in your path!"
+        exit 1
+    fi
+    sha256sum=$(which sha256sum)
+    if [[ $? -ne 0 ]]; then
+        echo "Error: cannot locate the program 'sha256sum' in your path!"
+        exit 1
+    fi
+}
+
+function git_clone() {
+    if [ -d inlets-aws-ec2-terraform ]; then
+        echo "Removing git repository directory inlets-aws-ec2-terraform"
+        rm -rf inlets-aws-ec2-terraform
+    fi
+    echo
+    echo "-----------------------------------------------------------------------------------"
+    echo
+    echo "Running 'git clone' command..."
+    git clone https://github.com/mbacchi/inlets-aws-terraform.git >/dev/null 2>&1
+    if [[ $? -ne 0 ]]; then
+        echo "Error: cannot clone the GitHub repository https://github.com/mbacchi/inlets-aws-terraform.git"
+        exit 1
+    else
+        echo
+        echo "Successfully cloned GitHub repository https://github.com/mbacchi/inlets-aws-terraform.git"
+    fi
+}
+
+function setup_exec_terraform() {
+    if [ ! -f ${LIGHTSAIL_KEYPAIR} ]; then
+        ssh-keygen -t rsa -b 4096 -N '' -f ${LIGHTSAIL_KEYPAIR}
+        if [[ $? -ne 0 ]]; then
+            echo "Error: cannot create keypair ${LIGHTSAIL_KEYPAIR}"
+            exit 1
+        fi
+    fi
+
+    if [[ "${LIGHTSAIL_KEYPAIR}" != "lightsail_keypair" ]]; then
+        sed -i "s/lightsail_keypair/${LIGHTSAIL_KEYPAIR}/" main.tf
+    fi
+
+    grep ${LIGHTSAIL_KEYPAIR} main.tf >/dev/null 2>&1
+    if [[ $? -ne 0 ]]; then
+        echo "Error: keypair ${LIGHTSAIL_KEYPAIR} not found in main.tf! Exiting..."
+        exit 1
+    fi
+
+    echo
+    echo "-----------------------------------------------------------------------------------"
+    echo
+    echo "Running 'terraform init' command..."
+    $terraform init 2>&1 | tee -a terraform.log
+    if [[ $? -ne 0 ]]; then
+        echo "Error: cannot run 'terraform init'. Look at log file 'terraform.$$.log' for errors."
+        exit 1
+    else
+        echo
+        echo "SUCCESS: 'terraform init' command successful."
+    fi
+
+    echo
+    echo "-----------------------------------------------------------------------------------"
+    echo
+    echo "Running 'terraform plan' command..."
+    token=$(head -c 16 /dev/urandom | sha256sum | cut -d" " -f1); \
+        $terraform plan -out=terraform_plan_inlets.$$.out  -var "token=$token" 2>&1 | tee -a terraform.log
+    if [[ $? -ne 0 ]]; then
+        echo "Error: cannot run 'terraform plan'. Look at log file 'terraform.$$.log' for errors."
+        exit 1
+    else
+        echo
+        echo "SUCCESS: 'terraform plan' command successful."
+    fi
+
+    echo
+    echo "-----------------------------------------------------------------------------------"
+    echo
+    echo "Running 'terraform apply' command..."
+    $terraform apply terraform_plan_inlets.$$.out 2>&1 | tee -a terraform.log
+    if [[ $? -ne 0 ]]; then
+        echo "Error: cannot run 'terraform apply'. Look at log file 'terraform.$$.log' for errors."
+        exit 1
+    else
+        echo
+        echo "SUCCESS: 'terraform apply' command successful."
+    fi
+}
+
+
+if [[ ${#} -lt "4" ]]; then
+    echo
+    echo "usage: $0 <lightsail_keypair> <aws_profile> <aws_region> <upstream_with_port>"
+    echo
+    echo "where:"
+    echo -e "<lightsail_keypair> the name of an existing Lightsail keypair, if you haven't created it \c"
+    echo "yet we will create it using the command:"
+    echo "      ssh-keygen -t rsa -b 4096 -N '' -f <lightsail_keypair>"
+    echo "<aws_profile> is the AWS profile previously configured in your ~/.aws/credentials file"
+    echo "<aws_region> is the AWS region you will be deploying this EC2 instance"
+    echo "<upstream_with_port> is the application with the port running on 127.0.0.1 (example: https://127.0.0.1:4000)"
+    exit 1
+fi
+
+LIGHTSAIL_KEYPAIR="${1}"
+AWS_PROFILE="${2}"
+AWS_REGION="${3}"
+UPSTREAM="${4}"
+export AWS_PROFILE AWS_REGION
+
+check_prereqs
+git_clone
+
+save_dir=$(pwd)
+cd inlets-aws-terraform/terraform/lightsail
+
+setup_exec_terraform
+
+TOKEN=$(cat terraform.log | grep -E "^inlets_token =" | sed -r 's/^inlets_token = (\w+)$/\1/')
+IP_ADDRESS=$(cat terraform.log | grep -E "^public_ip_address =" | sed -r 's/^public_ip_address = (.*)$/\1/')
+
+echo "-----------------------------------------------------------------------------------"
+echo
+echo
+echo "To connect to Inlets run the command:"
+echo
+echo "-----------------------------------------------------------------------------------"
+echo "inlets client  --remote=$IP_ADDRESS:80 --upstream=$UPSTREAM --token $TOKEN"
+echo "-----------------------------------------------------------------------------------"
+
+echo
+echo
+echo "To tear down the terraform infrastructure, run the following commands:"
+echo
+echo "cd ${save_dir}/inlets-aws-terraform/terraform/lightsail"
+echo "terraform destroy -var token=${TOKEN}"
+echo
+echo "You will be prompted to answer \"yes\" in order to actually remove the terraform resources."
+echo
+
+cd $save_dir


### PR DESCRIPTION
## Description
This adds two new scripts to provision AWS Lightsail
and AWS EC2 resources using Terraform.

Fixes: https://github.com/alexellis/inlets/issues/88

Signed-off-by: Matt Bacchi <mbacchi@gmail.com>

## How Has This Been Tested?
Using these two scripts I have brought up AWS Lightsail and EC2 instances as Inlets exit nodes and verified they work as expected.


## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
