### PR TITLE
Add control-plane option

### DIFF
--- a/cmd/inlets.go
+++ b/cmd/inlets.go
@@ -24,10 +24,14 @@ var inletsCmd = &cobra.Command{
 	Use:   "inlets",
 	Short: "Expose your local endpoints to the Internet.",
 	Long: `
-Inlets combines a reverse proxy and websocket tunnels to expose your internal and development 
-endpoints to the public Internet via an exit-node.
+Inlets combines a reverse proxy and websocket tunnels to expose your internal 
+and development endpoints to the public Internet via an exit-node.
 
-An exit-node may be a 5-10 USD VPS or any other computer with an IPv4 IP address.
+An exit-node may be a 5-10 USD VPS or any other computer with an IPv4 IP address. 
+You can also use inlets to bridge connect between private networks.
+
+It is strongly recommended to put a reverse proxy with TLS/SSL enabled such as 
+Nginx or Caddy in front of your inlets server to enable an encrypted tunnel.
 
 See: https://github.com/alexellis/inlets for more information.`,
 	Run: runInlets,

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -13,12 +13,15 @@ import (
 // serverCmd represents the server sub command.
 var serverCmd = &cobra.Command{
 	Use:   "server",
-	Short: "Start the tunnel server on a machine with a publicly-accessible IPv4 IP address such as a VPS.",
-	Long: `Start the tunnel server on a machine with a publicly-accessible IPv4 IP address such as a VPS.
+	Short: `Start the tunnel server.`,
+	Long: `Start the tunnel server on a machine with a publicly-accessible IPv4 IP 
+address such as a VPS.
 
 Example: inlets server -p 80 
 Example: inlets server --port 80 --control-port 8080
-Note: You can pass the --token argument followed by a token value to both the server and client to prevent unauthorized connections to the tunnel.`,
+
+Note: You can pass the --token argument followed by a token value to both the 
+server and client to prevent unauthorized connections to the tunnel.`,
 	RunE: runServer,
 }
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

## Description

This patch means that users can split their control plane from the
data plane. The control plane is used for the tunnel and the data
plane is used to serve traffic to external users via the
exit-node's IP.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with --port 80 --control-port 8080 and seeing that data
was not served on port 8080. Regression tested that when using
the same numeric value for both ports, the existing behaviour
was kept.

## How are existing users impacted? What migration steps/scripts do we need?

Fixes: #92 

No impact to existing users.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
