### PR TITLE
Add a hacky script to provision an endpoint on gcp

### DIFF
--- a/hack/provision-gcloud.sh
+++ b/hack/provision-gcloud.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+declare -r here="$(dirname "$(pwd -P)/${BASH_SOURCE[0]}")"
+
+SUFFIX=$(head -c 16 /dev/urandom | shasum | cut -c1-8)
+INSTANCENAME="inlets-$SUFFIX"
+SIZE="f1-micro"
+ZONE="europe-west2-b"
+USERDATA=${here}/userdata.sh
+
+gcloud compute firewall-rules create allow-inlets \
+    --allow tcp:80 \
+    --source-ranges 0.0.0.0/0
+
+echo "Creating: $INSTANCENAME"
+
+output=$(gcloud compute instances create $INSTANCENAME \
+    --machine-type=$SIZE \
+    --metadata-from-file=startup-script=$USERDATA \
+    --image-project="ubuntu-os-cloud" --image-family="ubuntu-1804-lts" \
+    --zone=$ZONE \
+    --format=json)
+
+if [ $? -eq 0 ]
+then
+
+    name=$( echo $output | jq -r '.[0].name' )
+    extip=$( echo $output | jq -r '.[0].networkInterfaces[0].accessConfigs[0].natIP' )
+
+    echo "=============================="
+    echo "Instance: $name has been created"
+    echo "IP: $extip"
+    echo "Login: gcloud compute ssh root@$name --zone=$ZONE"
+    echo "=============================="
+    echo "To destroy this instance run: gcloud compute instances delete $name --zone=$ZONE"
+fi


### PR DESCRIPTION
## Description
Add a script to provision a gcloud instance to run an inlets exit-node.
Script is hacky but has the same features as the DO one.

## How Has This Been Tested?
Manually tested a few times.

## How are existing users impacted? What migration steps/scripts do we need?
None.


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
