### PR TITLE
Update kube yamls

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ spec:
 ```
 
 You can now create an `Ingress` record, or `LoadBalancer` to connect to your server.
+Note that clients connecting to this server will have to specify port 8000 for their remote, as the default is 80.
 
 #### Try inlets with KinD (Kubernetes in Docker)
 

--- a/README.md
+++ b/README.md
@@ -312,16 +312,19 @@ You can run the client inside Kubernetes to expose your local services to the In
 Here's an example showing how to get ingress into your cluster for your OpenFaaS gateway and for Prometheus:
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inlets
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: inlets
   template:
     metadata:
       labels:
-        app: inlets
+        app.kubernetes.io/name: inlets
     spec:
       containers:
       - name: inlets
@@ -362,16 +365,19 @@ secret/inlets-token created
 * Bind the secret named `inlets-token` to the Deployment:
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inlets
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: inlets
   template:
     metadata:
       labels:
-        app: inlets
+        app.kubernetes.io/name: inlets
     spec:
       containers:
       - name: inlets
@@ -440,16 +446,19 @@ spec:
 * Create a `Deployment`:
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inlets
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: inlets
   template:
     metadata:
       labels:
-        app: inlets
+        app.kubernetes.io/name: inlets
     spec:
       containers:
       - name: inlets


### PR DESCRIPTION
## Description
Update example kube resources to the latest API version. Use standardised labels.

## How Has This Been Tested?
Manually, on GKE 1.13.

## How are existing users impacted? What migration steps/scripts do we need?
None.

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
