### PR TITLE
Update manifest templates to support K8s 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,12 +312,15 @@ You can run the client inside Kubernetes to expose your local services to the In
 Here's an example showing how to get ingress into your cluster for your OpenFaaS gateway and for Prometheus:
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inlets
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: inlets
   template:
     metadata:
       labels:
@@ -362,12 +365,15 @@ secret/inlets-token created
 * Bind the secret named `inlets-token` to the Deployment:
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inlets
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: inlets
   template:
     metadata:
       labels:
@@ -440,12 +446,15 @@ spec:
 * Create a `Deployment`:
 
 ```yaml
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inlets
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: inlets
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Description


## How Has This Been Tested?

Deployed example manifest into K8s 1.16

## How are existing users impacted? What migration steps/scripts do we need?

No impact.

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
