### PR TITLE
update control plane docs with correct option name

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ while [ true ] ; do sleep 5 && inlets server --upstream=http://192.168.0.28:8080
 You can bind two separate TCP ports for the user-facing port and the tunnel.
 
 * `--port` - the port for users to connect to and for serving data, i.e. the *Data Plane*
-* `--control-plane` - the port for the websocket to connect to i.e. the *Control Plane*
+* `--control-port` - the port for the websocket to connect to i.e. the *Control Plane*
 
 ### Docker & Kubernetes application development
 


### PR DESCRIPTION
The control plane is configured using the `--control-port` option instead of the `--control-plane` option

Signed-off-by: Tobias Brunner <tobias.brunner@vshn.ch>

## Description

The README says `--control-plane` where it actually is `--control-port`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Inlets says:

```
Error: unknown flag: --control-plane
Usage:
  inlets server [flags]

Flags:
  -c, --control-port int             control port for tunnel (default 8080)
      --disable-transport-wrapping   disable wrapping the transport that removes CORS headers for example
  -h, --help                         help for server
  -p, --port int                     port for server and for tunnel (default 8000)
      --print-token                  prints the token in server mode (default true)
  -t, --token string                 token for authentication
  -f, --token-from string            read the authentication token from a file

panic: unknown flag: --control-plane

goroutine 1 [running]:
main.main()
	/go/src/github.com/alexellis/inlets/main.go:15 +0x7e
```

## How are existing users impacted? What migration steps/scripts do we need?

Wrong documentation needs to be fixed.

## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
