### PR TITLE
remove excess Println in client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -37,7 +37,6 @@ func (c *Client) Connect() error {
 		headers.Add("Authorization", "Bearer "+c.Token)
 	}
 
-	fmt.Println(headers)
 	url := c.Remote
 	if !strings.HasPrefix(url, "ws") {
 		url = "ws://" + url


### PR DESCRIPTION
With this line present the token gets printed unintentionally which leads to an information disclosure

Signed-off-by: Tobias Brunner <tobias.brunner@vshn.ch>

## Description

This PR fixes #101 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Simple change :tm: 

## How are existing users impacted? What migration steps/scripts do we need?

See #101 

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
