### PR TITLE
improved startup logging with version information

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -61,6 +61,10 @@ Note: You can pass the --token argument followed by a token value to both the se
 
 // runClient does the actual work of reading the arguments passed to the client sub command.
 func runClient(cmd *cobra.Command, _ []string) error {
+
+	log.Printf("%s", WelcomeMessage)
+	log.Printf("Starting client - version %s", getVersion())
+
 	upstream, err := cmd.Flags().GetString("upstream")
 	if err != nil {
 		return errors.Wrap(err, "failed to get 'upstream' value")
@@ -109,8 +113,6 @@ func runClient(cmd *cobra.Command, _ []string) error {
 	if len(token) > 0 && printToken {
 		log.Printf("Token: %q", token)
 	}
-
-	fmt.Printf(WelcomeMessage)
 
 	inletsClient := client.Client{
 		Remote:      remote,

--- a/cmd/inlets.go
+++ b/cmd/inlets.go
@@ -13,7 +13,7 @@ var (
 	GitCommit string
 )
 
-const WelcomeMessage = "Welcome to inlets.dev! Find out more at https://github.com/alexellis/inlets\n\n"
+const WelcomeMessage = "Welcome to inlets.dev! Find out more at https://github.com/alexellis/inlets"
 
 func init() {
 	inletsCmd.AddCommand(versionCmd)
@@ -43,14 +43,17 @@ var versionCmd = &cobra.Command{
 	Run:   parseBaseCommand,
 }
 
+func getVersion() string {
+	if len(Version) != 0 {
+		return Version
+	}
+	return "dev"
+}
+
 func parseBaseCommand(_ *cobra.Command, _ []string) {
 	printLogo()
 
-	if len(Version) == 0 {
-		fmt.Println("Version: dev")
-	} else {
-		fmt.Println("Version:", Version)
-	}
+	fmt.Println("Version:", getVersion())
 	fmt.Println("Git Commit:", GitCommit)
 	os.Exit(0)
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -40,6 +40,9 @@ func init() {
 // runServer does the actual work of reading the arguments passed to the server sub command.
 func runServer(cmd *cobra.Command, _ []string) error {
 
+	log.Printf("%s", WelcomeMessage)
+	log.Printf("Starting server - version %s", getVersion())
+
 	tokenFile, err := cmd.Flags().GetString("token-from")
 	if err != nil {
 		return errors.Wrap(err, "failed to get 'token-from' value.")
@@ -87,8 +90,6 @@ func runServer(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get the 'disable-transport-wrapping' value.")
 	}
-
-	fmt.Printf(WelcomeMessage)
 
 	inletsServer := server.Server{
 		Port:        port,


### PR DESCRIPTION
## Description

This PR streamlines the startup logging of inlets to always print the welcome message first even if there are errors later in the process.

Also reporting the version number and inlets component started helps the operator to exactly know what's going on.

Printing the welcome message like the other log lines unifies the output in a consistent way.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It has been tested locally, here are the outputs tested:

```
% go run main.go version
 _       _      _            _
(_)_ __ | | ___| |_ ___   __| | _____   __
| | '_ \| |/ _ \ __/ __| / _` |/ _ \ \ / /
| | | | | |  __/ |_\__ \| (_| |  __/\ V /
|_|_| |_|_|\___|\__|___(_)__,_|\___| \_/

Version: dev
Git Commit: 

% go run main.go server 
2019/10/04 18:28:59 Welcome to inlets.dev! Find out more at https://github.com/alexellis/inlets
2019/10/04 18:28:59 Starting server - version dev
2019/10/04 18:28:59 Control Plane Listening on :8000
2019/10/04 18:28:59 Data Plane Listening on :8000
^Csignal: interrupt

% go run main.go client -u localhost
2019/10/04 18:29:10 Welcome to inlets.dev! Find out more at https://github.com/alexellis/inlets
2019/10/04 18:29:10 Starting client - version dev
2019/10/04 18:29:10 Upstream:  => localhost
INFO[0000] Connecting to proxy                           url="ws://127.0.0.1:8000/tunnel"
ERRO[0000] Failed to connect to proxy                    error="dial tcp 127.0.0.1:8000: connect: connection refused"
ERRO[0000] Failed to connect to proxy                    error="dial tcp 127.0.0.1:8000: connect: connection refused"
^Csignal: interrupt

% docker build --build-arg VERSION=tobrutesting --build-arg GIT_COMMIT=improved-startup-logging -t local/inlets .
% docker run --rm -it local/inlets version
 _       _      _            _
(_)_ __ | | ___| |_ ___   __| | _____   __
| | '_ \| |/ _ \ __/ __| / _` |/ _ \ \ / /
| | | | | |  __/ |_\__ \| (_| |  __/\ V /
|_|_| |_|_|\___|\__|___(_)__,_|\___| \_/

Version: tobrutesting
Git Commit: improved-startup-logging

% docker run --rm -it local/inlets server 
2019/10/04 16:41:01 Welcome to inlets.dev! Find out more at https://github.com/alexellis/inlets
2019/10/04 16:41:01 Starting server - version tobrutesting
2019/10/04 16:41:01 Control Plane Listening on :8000
2019/10/04 16:41:01 Data Plane Listening on :8000

% docker run --rm -it local/inlets client -u localhost
2019/10/04 16:41:23 Welcome to inlets.dev! Find out more at https://github.com/alexellis/inlets
2019/10/04 16:41:23 Starting client - version tobrutesting
2019/10/04 16:41:23 Upstream:  => localhost
INFO[0000] Connecting to proxy                           url="ws://127.0.0.1:8000/tunnel"
ERRO[0000] Failed to connect to proxy                    error="dial tcp 127.0.0.1:8000: connect: connection refused"
ERRO[0000] Failed to connect to proxy                    error="dial tcp 127.0.0.1:8000: connect: connection refused"

% docker run --rm -it local/inlets client             
2019/10/04 16:41:47 Welcome to inlets.dev! Find out more at https://github.com/alexellis/inlets
2019/10/04 16:41:47 Starting client - version tobrutesting
Error: upstream is missing in the client argument
Usage:
  inlets client [flags]
[...]
```

## How are existing users impacted? What migration steps/scripts do we need?

No migration is needed but brings a more consistent start logging behavior to Inlets user. The first impression matters! :100: 

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
