### PR TITLE
Fix build arg for version string in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ dist:
 
 .PHONY: docker
 docker:
-	docker build --build-arg Version=$(Version) --build-arg GIT_COMMIT=$(GitCommit) -t alexellis2/inlets:$(Version)$(PLATFORM) .
+	docker build --build-arg VERSION=$(Version) --build-arg GIT_COMMIT=$(GitCommit) -t alexellis2/inlets:$(Version)$(PLATFORM) .
 
 .PHONY: docker-login
 docker-login:


### PR DESCRIPTION
Docker build args are case sensitive. Otherwise docker build logs

`[Warning] One or more build-args [Version] were not consumed`

Signed-off-by: Tobias Brunner <tobias.brunner@vshn.ch>

## Description

The parameters passed to `--build-arg` need to have the same case as in the Dockerfile.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Before:

```
[...]
Step 19/19 : CMD ["--help"]
 ---> Running in a3b5257d2b66
Removing intermediate container a3b5257d2b66
 ---> 9bd1a0f44380
[Warning] One or more build-args [Version] were not consumed
Successfully built 9bd1a0f44380
[...]
```

After:

```
[...]
Step 19/19 : CMD ["--help"]
 ---> Running in 2d4522af6bc4
Removing intermediate container 2d4522af6bc4
 ---> a2d4ff4eeffd
Successfully built a2d4ff4eeffd
[..]
```

## How are existing users impacted? What migration steps/scripts do we need?

No migration needed. `make docker`, it just works :tm: 

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [X] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [X] signed-off my commits with `git commit -s`
- [ ] added unit tests
