### PR TITLE
Build multi-arch docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
 after_success:
   - make docker-login
   - make push
+  - make manifest
 
 before_deploy:
   - ./ci/hashgen.sh


### PR DESCRIPTION
## Description
Build and publish multi-arch docker images; closes  #60

## How Has This Been Tested?
I've built the image and pushed it to `matevzmihalic/inlets:2.5.0-2-g769dfe8-dirty`.
I've ran the image on Packet ARM server and on my computer and it shows help and version just fine. I didn't try to run client or server, but I think it should work. 

## How are existing users impacted? What migration steps/scripts do we need?


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [ ] added unit tests
