### PR TITLE
Use crypto subtle for constant time

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"log"
 	"net"
@@ -125,7 +126,7 @@ func (s *Server) dialerFor(id, host string) remotedialer.Dialer {
 
 func (s *Server) tokenValid(req *http.Request) bool {
 	auth := req.Header.Get("Authorization")
-	return len(s.Token) == 0 || auth == "Bearer "+s.Token
+	return subtle.ConstantTimeCompare([]byte(auth), []byte("Bearer "+s.Token)) == 1
 }
 
 func (s *Server) authorized(req *http.Request) (id string, ok bool, err error) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+)
+
+func Test_tokenValid_Valid(t *testing.T) {
+	token := "abcdefg"
+	s := &Server{Token: token}
+	r, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	r.Header.Set("Authorization", "Bearer "+token)
+	if !s.tokenValid(r) {
+		t.Error("expected isTokenValid to be true")
+	}
+}
+
+func Test_tokenValid_Invalid(t *testing.T) {
+	token := "abcdefg"
+	s := &Server{Token: token}
+	r, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	r.Header.Set("Authorization", "Bearer tuvwxyz")
+	if s.tokenValid(r) {
+		t.Error("expected isTokenValid to be false")
+	}
+}


### PR DESCRIPTION
## Description
This PR switches to using crypto/subtle for token comparison.

I don't get to write Go too often and would love extra feedback.

Closes #109 

## How Has This Been Tested?
Manually and with unit tests.

Good token
![inlets-good](https://user-images.githubusercontent.com/959573/66708625-aa10d400-ed10-11e9-9538-fb8f96872698.png)

Bad token
![inlets-bad](https://user-images.githubusercontent.com/959573/66708626-ac732e00-ed10-11e9-8202-ae95db29b7ce.png)

![2019-10-12_16-50](https://user-images.githubusercontent.com/959573/66708628-aed58800-ed10-11e9-8fd8-9819b06b3f82.png)

## How are existing users impacted? What migration steps/scripts do we need?
n/a

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [x] read the [CONTRIBUTION](https://github.com/alexellis/inlets/blob/master/CONTRIBUTING.md) guide
- [x] signed-off my commits with `git commit -s`
- [x] added unit tests
